### PR TITLE
Use CRAC api from org.crac and upadte project website

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -54,12 +54,6 @@ jobs:
         sudo tar -axf $archive
         echo JDK=${archive%%.tar.gz} >> $GITHUB_ENV
 
-    - name: Use specific API
-      if: matrix.api != 'jdk'
-      run: |
-        find -name '*.java' | xargs sed -i 's/jdk\.crac/${{ matrix.api }}.crac/g'
-        git diff
-
     - run: |
         if [ ${{ matrix.build_jdk }} = crac ]; then
           export JAVA_HOME=${{ env.JDK }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -54,6 +54,12 @@ jobs:
         sudo tar -axf $archive
         echo JDK=${archive%%.tar.gz} >> $GITHUB_ENV
 
+    - name: Use specific API
+      if: matrix.api != 'org'
+      run: |
+        find -name '*.java' | xargs sed -i 's/org\.crac/${{ matrix.api }}.crac/g'
+        git diff
+
     - run: |
         if [ ${{ matrix.build_jdk }} = crac ]; then
           export JAVA_HOME=${{ env.JDK }}

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <name>example-jetty</name>
-  <!-- FIXME change it to the project's website -->
-  <url>http://www.example.com</url>
+  <url>https://github.com/CRaC/example-jetty</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -27,6 +26,11 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <version>9.4.30.v20200611</version>
+    </dependency>
+    <dependency>
+      <groupId>org.crac</groupId>
+      <artifactId>crac</artifactId>
+      <version>0.1.3</version>
     </dependency>
   </dependencies>
 
@@ -54,13 +58,6 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
       </properties>
-      <dependencies>
-        <dependency>
-          <groupId>io.github.crac</groupId>
-          <artifactId>org-crac</artifactId>
-          <version>0.1.0</version>
-        </dependency>
-      </dependencies>
     </profile>
   </profiles>
 

--- a/src/main/java/com/example/App.java
+++ b/src/main/java/com/example/App.java
@@ -7,9 +7,9 @@ import java.io.IOException;
 
 // org.crac could be used instead of jdk.crac
 // https://github.com/CRaC/docs#orgcrac
-import jdk.crac.Context;
-import jdk.crac.Core;
-import jdk.crac.Resource;
+import org.crac.Context;
+import org.crac.Core;
+import org.crac.Resource;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;


### PR DESCRIPTION
Directly depends on API from `crac` JDK build  could be troublesome for macos users to try out the example, since we only  have linux build now