### PR TITLE
Jetty stop connectors

### DIFF
--- a/src/main/java/com/example/App.java
+++ b/src/main/java/com/example/App.java
@@ -1,5 +1,6 @@
 package com.example;
 
+import java.util.Arrays;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.ServletException;
@@ -13,40 +14,28 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.util.component.LifeCycle;
 
-class ServerManager implements Resource
-{
+class ServerManager implements Resource {
     Server server;
-    Thread preventExitThread;
 
     public ServerManager(int port, Handler handler) throws Exception {
         server = new Server(8080);
         server.setHandler(handler);
         server.start();
         Core.getGlobalContext().register(this);
-
-        // beforeCheckpoint implemented in simplest manner: shutdown the jetty
-        // server. There may be no non-daemon threads left, so JVM may exit.
-        // Here we provides a thread that will keep JVM running.
-        preventExitThread = new Thread(() -> {
-            while (true) {
-                try {
-                    Thread.sleep(1_000_000);
-                } catch (InterruptedException e) {
-                }
-            }
-        });
-        preventExitThread.start();
+        server.join();
     }
 
     @Override
-    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
-        server.stop();
+    public void beforeCheckpoint(Context<? extends Resource> context) {
+        // Stop the connectors only and keep the expensive application running
+        Arrays.asList(server.getConnectors()).forEach(c -> LifeCycle.stop(c));
     }
 
     @Override
-    public void afterRestore(Context<? extends Resource> context) throws Exception {
-        server.start();
+    public void afterRestore(Context<? extends Resource> context) {
+        Arrays.asList(server.getConnectors()).forEach(c -> LifeCycle.start(c));
     }
 }
 
@@ -58,16 +47,14 @@ public class App extends AbstractHandler
                        Request baseRequest,
                        HttpServletRequest request,
                        HttpServletResponse response)
-        throws IOException, ServletException
-    {
+        throws IOException {
         response.setContentType("text/html;charset=utf-8");
         response.setStatus(HttpServletResponse.SC_OK);
         baseRequest.setHandled(true);
         response.getWriter().println("Hello World");
     }
 
-    public static void main( String[] args ) throws Exception
-    {
+    public static void main( String[] args ) throws Exception {
         serverManager = new ServerManager(8080, new App());
     }
 }

--- a/src/main/java/com/example/App.java
+++ b/src/main/java/com/example/App.java
@@ -24,7 +24,6 @@ class ServerManager implements Resource {
         server.setHandler(handler);
         server.start();
         Core.getGlobalContext().register(this);
-        server.join();
     }
 
     @Override
@@ -56,5 +55,6 @@ public class App extends AbstractHandler
 
     public static void main( String[] args ) throws Exception {
         serverManager = new ServerManager(8080, new App());
+        serverManager.server.join();
     }
 }


### PR DESCRIPTION
Stopping the entire server can make for an expensive restart, as all the webapplications might need to be rescanned for annotations on restore.  This PR only stops/starts the connectors, which contain the listening sockets.
